### PR TITLE
Fix grammatical error "and" in config and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![mailblog](https://user-images.githubusercontent.com/17960677/145203419-09243272-0e8f-4974-8843-c21361133a00.png)
 
-> MailBlog is a blog that is managed via your Email Inbox and allows you to create and manage your own blog posts by sending and email.
+> MailBlog is a blog that is managed via your Email Inbox and allows you to create and manage your own blog posts by sending an email.
 
 ## Email Configuration
 

--- a/components/config.js
+++ b/components/config.js
@@ -2,7 +2,7 @@ const config = {
   name: "Mail Blog",
   description: "Inbox powered Blog",
   longDescription:
-    "MailBlog is a blog that is managed via your Email Inbox and allows you to create and manage your own blog posts by sending and email.",
+    "MailBlog is a blog that is managed via your Email Inbox and allows you to create and manage your own blog posts by sending an email.",
   logo: "/assets/images/logo.png",
   footer: "© 2021 Mail Blog. All rights reserved",
   socials: {


### PR DESCRIPTION
Using "and" in the sentence, "MailBlog is a blog that is managed via your Email Inbox and allows you to create and manage your own blog posts by **sending and email**," is incorrect grammar and I corrected it to "an".

The image in the README.md should also be updated to match the change:
![Image](https://i.imgur.com/4MSWUj5.png)